### PR TITLE
01 fragment replace multiple activities

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,6 +3,7 @@
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">
       <map>
+        <entry key="..\:/Users/Kareem.Adesola/AndroidStudioProjects/PayPad/app/src/main/res/layout/activity_main.xml" value="0.11474164133738601" />
         <entry key="..\:/Users/Kareem.Adesola/Downloads/PayPad/app/src/main/res/layout-v21/fragment_payment_successful.xml" value="0.2265625" />
         <entry key="..\:/Users/Kareem.Adesola/Downloads/PayPad/app/src/main/res/layout/activity_main.xml" value="0.1" />
         <entry key="..\:/Users/Kareem.Adesola/Downloads/PayPad/app/src/main/res/layout/fragment_main.xml" value="0.3984375" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.0'
-    testImplementation 'junit:junit:4.+'
+    testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"

--- a/app/src/main/java/com/example/paypad/MainActivity.kt
+++ b/app/src/main/java/com/example/paypad/MainActivity.kt
@@ -1,16 +1,15 @@
 package com.example.paypad
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
-import androidx.navigation.ui.setupActionBarWithNavController
 import com.example.paypad.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
     private lateinit var navController: NavController
-    
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)


### PR DESCRIPTION
Use an activity and fragments rather than using two activities. This makes it more inituitive since navigation is concerned and also more scalable